### PR TITLE
Hard wrap existing docs, Tabbed blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ Then run the following:
 
 Navigate to `http://localhost/` to preview the changes.
 
-This setup supports live-reloading so all that is needed is to save the markdown files and/or `mkdocs.yaml` file to trigger a reload.
+This setup supports live-reloading so all that is needed is to save the markdown files
+and/or `mkdocs.yaml` file to trigger a reload.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -90,6 +90,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
 extra:
   generator: false # Disable watermark
   analytics:

--- a/src/concepts/mantra.md
+++ b/src/concepts/mantra.md
@@ -3,14 +3,27 @@
 The *DataJoint Mantra* consists of three main objectives:
 
 - Simplify your queries through an intuitive [query language](./#query-language).
-- Make automated, [reproducible computation](./#reproducible-computation) by integrating computation with the data model.
+- Make automated, [reproducible computation](./#reproducible-computation) by integrating
+  computation with the data model.
 - Ensure validity of your data through [referential integrity](./#referential-integrity).
 
 ## Query Language
 
-Writing good, optimized [SQL](https://en.wikipedia.org/wiki/SQL) queries can be difficult and often becomes a barrier for individuals lacking experience in [computer science](https://en.wikipedia.org/wiki/Computer_science) and programming. That said, we don't feel this should discourage the use of databases. Databases help to structure our daily lives which streamlines the time required to glean insights and build robust applications from truth. [SQL](https://en.wikipedia.org/wiki/SQL) is powerful but requires practice which we feel is the real fault in the language.
+Writing good, optimized [SQL](https://en.wikipedia.org/wiki/SQL) queries can be
+difficult and often becomes a barrier for individuals lacking experience in
+[computer science](https://en.wikipedia.org/wiki/Computer_science) and programming.
+That said, we don't feel this should discourage the use of databases. Databases help to
+structure our daily lives which streamlines the time required to glean insights and
+build robust applications from truth. [SQL](https://en.wikipedia.org/wiki/SQL) is
+powerful but requires practice which we feel is the real fault in the language.
 
-To address this, the DataJoint query language serves as a query builder and optimizer for [SQL](https://en.wikipedia.org/wiki/SQL). It leverages the stack's own operator precedence and combines it with both operator overloading and [SQL](https://en.wikipedia.org/wiki/SQL) algebra to achieve a more intuitive experience. Additionally, interoperability between Python and MATLAB is crucial due to the diversity of tools available to scientists. So much so that this is a guiding principle in [FAIR](https://www.go-fair.org/fair-principles/).
+To address this, the DataJoint query language serves as a query builder and optimizer
+for [SQL](https://en.wikipedia.org/wiki/SQL). It leverages the stack's own operator
+precedence and combines it with both operator overloading and 
+[SQL](https://en.wikipedia.org/wiki/SQL) algebra to achieve a more intuitive experience.
+Additionally, interoperability between Python and MATLAB is crucial due to the
+diversity of tools available to scientists. So much so that this is a guiding principle
+in [FAIR](https://www.go-fair.org/fair-principles/).
 
 Case in point, here is a comparison of equivalent queries:
 
@@ -25,32 +38,55 @@ WHERE (
 );
 ```
 
-*DataJoint (Python)*
-```python
-Rectangle * Area & dict(shape_height=2, shape_area=8)
-```
+=== "*DataJoint (Python)*"
+    ```python
+    Rectangle * Area & dict(shape_height=2, shape_area=8)
+    ```
 
-*DataJoint (MATLAB)*
-```matlab
-shapes.Rectangle * shapes.Area & struct('shape_height', 2, 'shape_area', 8)
-```
+=== "*DataJoint (MATLAB)*"
+    ```matlab
+    shapes.Rectangle * shapes.Area & struct('shape_height', 2, 'shape_area', 8)
+    ```
 
 ## Reproducible Computation
 
-Reproducibility is a key concept within the scientific community since research is largely conducted, shared, and reviewed in the public domain. This is necessary to independently validate discoveries and have others support new findings. Such a practice is well advocated in the scientific community as [open science](Open_science).
+Reproducibility is a key concept within the scientific community since research is
+largely conducted, shared, and reviewed in the public domain. This is necessary to
+independently validate discoveries and have others support new findings. Such a
+practice is well advocated in the scientific community as 
+[open science](Open_science).
 
-Yet, reliably reproducing computed results of others has proven difficult since there are many factors that affect the determinism of a process e.g. hardware, software environment, scripts, input data, seeding, etc.
+Yet, reliably reproducing computed results of others has proven difficult since there
+are many factors that affect the determinism of a process e.g. hardware, software
+environment, scripts, input data, seeding, etc.
 
-DataJoint pipelines address these challenges by allowing computation to be defined such that they are associated *with* an entity. Drawing relationships between many entities we can create a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) that describes a compute workflow as an [entity-relationship model](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model).
+DataJoint pipelines address these challenges by allowing computation to be defined such
+that they are associated *with* an entity. Drawing relationships between many entities
+we can create a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) that
+describes a compute workflow as an 
+[entity-relationship model](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model).
 
-For instance, an entity such as `Area` could represent the computed value of a parent entity, `Rectangle`. Therefore, we feel it should be reasonable when defining `Area` to include the specification of a computation that automates how `Area` is generated based on relation to `Rectangle`.
+For instance, an entity such as `Area` could represent the computed value of a parent
+entity, `Rectangle`. Therefore, we feel it should be reasonable when defining `Area` to
+include the specification of a computation that automates how `Area` is generated based
+on relation to `Rectangle`.
 
 ## Referential Integrity
 
-Referential integrity is the concept of keeping all your data consistent and up-to-date. The goal is to ensure [data pipelines](../../glossary#data-pipeline) always reflect the truth of how data was created.
+Referential integrity is the concept of keeping all your data consistent and up-to-date.
+The goal is to ensure [data pipelines](../../glossary#data-pipeline) always reflect the
+truth of how data was created.
 
-In the realm of databases, entities can be related to one another through [foreign keys](https://en.wikipedia.org/wiki/Foreign_key). However, our opinionated view is that foreign keys on [primary keys](https://en.wikipedia.org/wiki/Primary_key) should enforce the contraint.
+In the realm of databases, entities can be related to one another through 
+[foreign keys](https://en.wikipedia.org/wiki/Foreign_key). However, our opinionated view is that
+foreign keys on [primary keys](https://en.wikipedia.org/wiki/Primary_key) should
+enforce the contraint.
 
-What this means is that our data model always reflects the truth. When a parent entity is removed, all child computed values will also be removed since they no longer have meaning without the subject. There is not a clear way to reproduce the results otherwise.
+What this means is that our data model always reflects the truth. When a parent entity
+is removed, all child computed values will also be removed since they no longer have
+meaning without the subject. There is not a clear way to reproduce the results
+otherwise.
 
-An important consequence to note is that deletes take longer as a result since they must be cascaded down to all the descendants. We believe this to be a feature as it is the behavior most inline with typical expectations. Deletes should be done cautiously. 
+An important consequence to note is that deletes take longer as a result since they must
+be cascaded down to all the descendants. We believe this to be a feature as it is the
+behavior most inline with typical expectations. Deletes should be done cautiously. 

--- a/src/concepts/query-lang/datatypes.md
+++ b/src/concepts/query-lang/datatypes.md
@@ -1,10 +1,14 @@
 # Datatypes
 
-Throughout the DataJoint ecosystem, there are several datatypes that are used to define tables with cross-platform support i.e. Python, MATLAB. It is important to understand these types as they can have implications in the queries you form and the capacity of their storage.
+Throughout the DataJoint ecosystem, there are several datatypes that are used to define
+tables with cross-platform support i.e. Python, MATLAB. It is important to understand
+these types as they can have implications in the queries you form and the capacity of
+their storage.
 
 ## Standard Types
 
-These types are largely wrappers around existing types in the current [query backend](../../ref-integrity/query-backend) for [data pipelines](../../../glossary#data-pipeline).
+These types are largely wrappers around existing types in the current 
+[query backend](../../ref-integrity/query-backend) for [data pipelines](../../../glossary#data-pipeline).
 
 | Datatype | Description | Size | Example |
 | --- | --- | ---| --- |

--- a/src/core.md
+++ b/src/core.md
@@ -1,6 +1,8 @@
 # Core
 
-DataJoint Core projects are fully open-source and are built to develop, define, manage, and visualize [data pipelines](../glossary#data-pipeline). Below are the projects that make up the family of core open-source projects.
+DataJoint Core projects are fully open-source and are built to develop, define, manage,
+and visualize [data pipelines](../glossary#data-pipeline). Below are the projects that
+make up the family of core open-source projects.
 
 ## [API](https://en.wikipedia.org/wiki/API)s
 

--- a/src/elements/concepts.md
+++ b/src/elements/concepts.md
@@ -4,26 +4,31 @@ The following conventions describe the DataJoint Python API implementation.
 
 ## DataJoint Schemas
 
-The DataJoint Python API allows creating _database schemas_, which are namespaces for collections of related tables.
+The DataJoint Python API allows creating _database schemas_, which are namespaces for
+collections of related tables.
 
-The following commands declare a new schema and create the object named `schema` to reference the database schema.
+The following commands declare a new schema and create the object named `schema` to
+reference the database schema.
 
 ```python
 import datajoint as dj
 schema = dj.schema('<schema_name>')
 ```
 
-We follow the convention of having only one schema defined per Python module.
-Then such a module becomes a _DataJoint schema_ comprising a Python module with a corresponding _database schema_.
+We follow the convention of having only one schema defined per Python module. Then such
+a module becomes a _DataJoint schema_ comprising a Python module with a
+corresponding _database schema_.
 
-The module's `schema` object is then used as the decorator for classes that define tables in the database.
+The module's `schema` object is then used as the decorator for classes that define
+tables in the database.
 
 ## Elements
 
-An Element is a software package defining one or more DataJoint schemas serving a particular purpose.
-By convention, such packages are hosted in individual GitHub repositories.
-For example, Element `element_calcium_imaging` is hosted at https://github.com/datajoint/element-calcium-imaging
-and contains two DataJoint schemas: `scan` and `imaging`.
+An Element is a software package defining one or more DataJoint schemas serving a
+particular purpose. By convention, such packages are hosted in individual GitHub
+repositories. For example, Element `element_calcium_imaging` is hosted at
+https://github.com/datajoint/element-calcium-imaging and contains two DataJoint
+schemas: `scan` and `imaging`.
 
 ### YouTube Tutorials
 
@@ -61,13 +66,20 @@ def activate(schema_name):
 	schema.activate(schema_name)
 ```
 
-However, many activate functions perform other work associated with activating the schema such as activating other schemas upstream.
+However, many activate functions perform other work associated with activating the
+schema such as activating other schemas upstream.
 
 ### Linking Module
 
-To make the code more modular with fewer dependencies, Element modules do not `import` upstream schemas directly. 
-Instead, all required classes and functions must be defined in a `linking_module` and passed to the module's `activate` function. By keeping all upstream requirements in the linking module, all Elements can be activated as part of any larger pipeline.
+To make the code more modular with fewer dependencies, Element modules do not `import`
+upstream schemas directly. Instead, all required classes and functions must be defined
+in a `linking_module` and passed to the module's `activate` function. By keeping all
+upstream requirements in the linking module, all Elements can be activated as part of
+any larger pipeline.
 
-For instance, the [Scan module](https://github.com/datajoint/element-calcium-imaging/blob/main/element_calcium_imaging/scan.py) receives
-its required functions from the linking module passed into the module's `activate` function.
-See the [corresponding workflow](https://github.com/datajoint/workflow-calcium-imaging/blob/main/workflow_calcium_imaging/pipeline.py) for an example of how the linking module is passed into the Element's module.
+For instance, the 
+[Scan module](https://github.com/datajoint/element-calcium-imaging/blob/main/element_calcium_imaging/scan.py)
+receives its required functions from the linking module passed into the module's
+`activate` function. See the 
+[corresponding workflow](https://github.com/datajoint/workflow-calcium-imaging/blob/main/workflow_calcium_imaging/pipeline.py)
+for an example of how the linking module is passed into the Element's module.

--- a/src/elements/developer-instructions.md
+++ b/src/elements/developer-instructions.md
@@ -2,7 +2,9 @@
 
 ## Development mode installation
 
-- We recommend doing development work in a conda environment. For information on setting up conda for the first time, see [this article](https://towardsdatascience.com/get-your-computer-ready-for-machine-learning-how-what-and-why-you-should-use-anaconda-miniconda-d213444f36d6).
+- We recommend doing development work in a conda environment. For information on setting
+  up conda for the first time, see 
+  [this article](https://towardsdatascience.com/get-your-computer-ready-for-machine-learning-how-what-and-why-you-should-use-anaconda-miniconda-d213444f36d6).
 
 - This method allows you to modify the source code for example DataJoint
   workflows (e.g. `workflow-array-ephys`) and their
@@ -11,7 +13,10 @@
 - Launch a new terminal and change directory to where you want to clone the
   repositories (e.g., `bash cd ~/Projects`)
 
-- Clone the relevant workflow and refer to the `requirements.txt` in the workflow for the list of Elements to clone and install as editable. You will also need to install `element-interface` 
+- Clone the relevant workflow and refer to the `requirements.txt` in the workflow for
+  the list of Elements to clone and install as editable. You will also need to install
+  `element-interface` 
+
     ```console
     deps=("lab" "animal" "session" "interface" "<others>")
     for repo in $deps # clone each
@@ -26,31 +31,36 @@
 
 ## Optionally drop all schemas
 
-If you need to drop all schemas to start fresh, you'll need to do following the dependency order. Refer to the workflow's notebook (`notebooks/06-drop-optional.ipynb`) for the drop order.
+If you need to drop all schemas to start fresh, you'll need to do following the
+dependency order. Refer to the workflow's notebook
+(`notebooks/06-drop-optional.ipynb`) for the drop order.
 
 ## Run integration tests
 
-- Download the test dataset to your local machine. Note the directory where the
-  dataset is saved (e.g. `/tmp/testset`).
+- Download the test dataset to your local machine. Note the directory where the dataset
+  is saved (e.g. `/tmp/testset`).
 
-- Create an `.env` file within the `docker` directory with the following content. 
+- Create an `.env` file within the `docker` directory with the following content.
   Replace `/tmp/testset` with the directory where you have the test dataset downloaded.
   `TEST_DATA_DIR=/tmp/testset`
 
-- If testing an unreleased version of the `element` or your fork of an `element`
-  or the `workflow`, within the `Dockerfile` uncomment the lines from the
-  different options presented. This will allow you to install the repositories
-  of interest and run the integration tests on those packages. Be sure that the
-  `element` package version matches the version in the `requirements.txt` of the
-  `workflow`.
+- If testing an unreleased version of the `element` or your fork of an `element` or the
+  `workflow`, within the `Dockerfile` uncomment the lines from the different options
+  presented. This will allow you to install the repositories of interest and run the
+  integration tests on those packages. Be sure that the `element` package version
+  matches the version in the `requirements.txt` of the `workflow`.
 
 - Run the Docker container.
-  ```
+  ```console
   docker-compose -f ./docker/docker-compose-test.yaml up --build
   ```
 
 ## Jupytext
-We maintain `.py` script copies of all didactic notebooks to facilitate the GitHub review process. From the main workflow directory, we recommend the following command to generate these copies. You may wish to save this as an alias in your `.bash_profile`. Note that the jupytext sync features may cause issues with the original notebooks.
+
+We maintain `.py` script copies of all didactic notebooks to facilitate the GitHub
+review process. From the main workflow directory, we recommend the following command to
+generate these copies. You may wish to save this as an alias in your `.bash_profile`.
+Note that the jupytext sync features may cause issues with the original notebooks.
 
    ```console
    pip install jupytext

--- a/src/elements/management/adopt.md
+++ b/src/elements/management/adopt.md
@@ -4,9 +4,13 @@ You have several options for adopting DataJoint workflows for your own experimen
 
 ## Adopt independently
 
-DataJoint Elements are designed for adoption by independent users with moderate software development skills, good understanding of DataJoint principles, and adequate IT expertise or support.
+DataJoint Elements are designed for adoption by independent users with moderate software
+development skills, good understanding of DataJoint principles, and adequate IT
+expertise or support.
 
-If you have not yet used DataJoint, we recommend completing our online training tutorials or attending a workshop either online or in person.  Interactive tutorials can be found on [DataJoint CodeBook](https://codebook.datajoint.io).
+If you have not yet used DataJoint, we recommend completing our online training
+tutorials or attending a workshop either online or in person.  Interactive tutorials
+can be found on [DataJoint CodeBook](https://codebook.datajoint.io).
 
 ## Support from DataJoint
 

--- a/src/elements/management/governance.md
+++ b/src/elements/management/governance.md
@@ -2,7 +2,10 @@
 
 ## Funding
 
-This Resource is supported by the National Institute Of Neurological Disorders And Stroke of the National Institutes of Health under Award Number U24NS116470. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.
+This Resource is supported by the National Institute Of Neurological Disorders And
+Stroke of the National Institutes of Health under Award Number U24NS116470. The content
+is solely the responsibility of the authors and does not necessarily represent the
+official views of the National Institutes of Health.
 
 ## Scientific Steering Group
 

--- a/src/elements/management/outreach.md
+++ b/src/elements/management/outreach.md
@@ -1,25 +1,36 @@
 # Outreach Plan
 
-Broad engagement with the neuroscience community is necessary for the optimization, integration, and adoption of the Resource components.
+Broad engagement with the neuroscience community is necessary for the optimization,
+integration, and adoption of the Resource components.
 
 We conduct five types of outreach activities that require different approaches:
 
 # 1. Precursor Projects
 
-Our [Selection Process](../selection) requires a "Precursor Project" for any new experiment modality to be included in DataJoint Elements.
-A precursor project is a project that develops a DataJoint pipeline for its own experiments either independently or in collaboration with our team.
-We reach out to teams who develop DataJoint pipelines for new experiment paradigms and modalities to identify essential design motifs, analysis tools, and related tools and interfaces.
-We interview the core team to learn about their collaborative culture, practices, and procedures.
-We jointly review their open-source code and their plans for dissemination.
-In many cases, our team already collaborates with such teams through our other projects and we have a good understanding of their process.
-As we develop a new Element to support the new modality, we remain in contact with the team to include their contribution, solicit feedback, and evaluate design tradeoffs. When the new Element is released, a full attribution is given to the Precursor Project.
+Our [Selection Process](../selection) requires a "Precursor Project" for any new
+experiment modality to be included in DataJoint Elements. A precursor project is a
+project that develops a DataJoint pipeline for its own experiments either independently
+or in collaboration with our team. We reach out to teams who develop DataJoint
+pipelines for new experiment paradigms and modalities to identify essential design
+motifs, analysis tools, and related tools and interfaces. We interview the core team to
+learn about their collaborative culture, practices, and procedures. We jointly review
+their open-source code and their plans for dissemination. In many cases, our team
+already collaborates with such teams through our other projects and we have a good
+understanding of their process. As we develop a new Element to support the new
+modality, we remain in contact with the team to include their contribution, solicit
+feedback, and evaluate design tradeoffs. When the new Element is released, a full
+attribution is given to the Precursor Project.
 
-**Rationale:** The Resource does not aim to develop fundamentally new solutions for neurophysiology data acquisition and analysis. Rather it aims to systematize and disseminate existing open-source tools proven in leading research projects.
+**Rationale:** The Resource does not aim to develop fundamentally new solutions for
+  neurophysiology data acquisition and analysis. Rather it aims to systematize and
+  disseminate existing open-source tools proven in leading research projects.
 
 # 2. Tool Developers
 
-DataJoint pipelines rely on analysis tools, atlases, data standards, archives and catalogs, and other neuroinformatics resources developed and maintained by the broader scientific community.
-To ensure sustainability of the Resource, we reach out to the tool developer to establish joint sustainability roadmaps.
+DataJoint pipelines rely on analysis tools, atlases, data standards, archives and
+catalogs, and other neuroinformatics resources developed and maintained by the broader
+scientific community. To ensure sustainability of the Resource, we reach out to the
+tool developer to establish joint sustainability roadmaps.
 
 # 3. Dissemination
 

--- a/src/elements/management/plan.md
+++ b/src/elements/management/plan.md
@@ -1,6 +1,8 @@
 # Management Plan
 
-DataJoint Elements has established a Resource Management Plan to select projects for development, to assure quality, and to disseminate its output as summarized in the figure below:
+DataJoint Elements has established a Resource Management Plan to select projects for
+development, to assure quality, and to disseminate its output as summarized in the
+figure below:
 
 ![Resource Management Plan](../../images/management-plan.png)
 

--- a/src/elements/management/quality-assurance.md
+++ b/src/elements/management/quality-assurance.md
@@ -1,65 +1,111 @@
 # Quality Assurance
 
-DataJoint and DataJoint Elements serve as a framework and starting points for numerous new projects, setting the standard of quality for data architecture and software design. To ensure higher quality, the following policies have been adopted into the software development lifecycle (SDLC).
+DataJoint and DataJoint Elements serve as a framework and starting points for numerous
+new projects, setting the standard of quality for data architecture and software
+design. To ensure higher quality, the following policies have been adopted into the
+software development lifecycle (SDLC).
 
 ## Coding Standards
 
 When writing code, the following principles should be observed.
 
-- **Style**: Code shall be written for clear readability. Uniform and clear naming conventions, module structure, and formatting requirements shall be established across all components of the project. Python's [PEP8](https://www.python.org/dev/peps/pep-0008/#naming-conventions) standard offers clear guidance to this regard which can similarly be applied to all languages.
+- **Style**: Code shall be written for clear readability. Uniform and clear naming
+    conventions, module structure, and formatting requirements shall be established
+    across all components of the project. Python's 
+    [PEP8](https://www.python.org/dev/peps/pep-0008/#naming-conventions) standard offers
+    clear guidance to this regard which can similarly be applied to all languages.
   - Python code is formatted with the [black](https://github.com/psf/black) code formatter.
   - Line length should be a maximum of 88 characters.
 
-- **Maintenance Overhead**: Code base size should be noted to prevent large, unnecessarily complex solutions from being introduced. The idea is that the larger the code base, the more there is to review and maintain. Therefore, we should aim to find a compromise where we can keep the code base from becoming too large without adding convoluted complexity.
+- **Maintenance Overhead**: Code base size should be noted to prevent large,
+    unnecessarily complex solutions from being introduced. The idea is that the larger
+    the code base, the more there is to review and maintain. Therefore, we should aim
+    to find a compromise where we can keep the code base from becoming too large
+    without adding convoluted complexity.
 
-- **Performance**: Performance drawbacks should be avoided, controlled, or, at least, be properly monitored and justified. For instance: memory management, garbage collection, disk reads/writes, and processing overhead should be regarded to ensure that an efficient solution is achieved.
+- **Performance**: Performance drawbacks should be avoided, controlled, or, at least, be
+    properly monitored and justified. For instance: memory management, garbage
+    collection, disk reads/writes, and processing overhead should be regarded to ensure
+    that an efficient solution is achieved.
 
 ## Automated Testing
 
-All components and their revisions must include appropriate automated software testing to be considered for release. The core framework must undergo thorough performance evaluation and comprehensive integration testing.
+All components and their revisions must include appropriate automated software testing
+to be considered for release. The core framework must undergo thorough performance
+evaluation and comprehensive integration testing.
 
 Generally, this includes tests related to:
 
-- **Syntax**: Verify that the code base does not contain any syntax errors and will run or compile successfully.
+- **Syntax**: Verify that the code base does not contain any syntax errors and will run
+    or compile successfully.
 
-- **Unit & Integration**: Verify that low-level, method-specific tests (unit tests) and any tests related coordinated interface between methods (integration tests) pass successfully. Typically, when bugs are patched or features are introduced, unit and integration tests are added to ensure that the use-case intended to be satisfied is accounted for. This helps us prevent any regression in functionality.
+- **Unit & Integration**: Verify that low-level, method-specific tests (unit tests) and
+    any tests related coordinated interface between methods (integration tests) pass
+    successfully. Typically, when bugs are patched or features are introduced, unit and
+    integration tests are added to ensure that the use-case intended to be satisfied is
+    accounted for. This helps us prevent any regression in functionality.
 
 - **Style**: Verify that the code base adheres to style guides for optimal readability.
 
-- **Code Coverage**: Verify that the code base has similar or better code coverage than the last run.
+- **Code Coverage**: Verify that the code base has similar or better code coverage than
+    the last run.
 
 ## Code Reviews
 
-When introducing new code to the code base, the following will be required for acceptance by DataJoint core team into the main code repository.
+When introducing new code to the code base, the following will be required for
+acceptance by DataJoint core team into the main code repository.
 
 - **Independence**: Proposed changes should not directly alter the code base in the review process. New changes should be applied separately on a copy of the code base and proposed for review by the DataJoint core team. For example, apply changes on a GitHub fork and open a pull request targeting the `main` branch once ready for review.
 
-- **Etiquette**: An author who has requested for a code for review should not accept and merge their own code to the code base. A reviewer should not commit any suggestions directly to the authors proposed changes but rather should allow the author to review.
+- **Etiquette**: An author who has requested for a code for review should not accept and
+    merge their own code to the code base. A reviewer should not commit any suggestions
+    directly to the authors proposed changes but rather should allow the author to
+    review.
 
 - **Coding Standards**: Ensure the above coding standards are respected.
 
-- **Summary**: A description should be included that summarizes and highlights the notable changes that are being proposed.
+- **Summary**: A description should be included that summarizes and highlights the
+    notable changes that are being proposed.
 
-- **Issue Reference**: Any bugs or feature requests that have been filed in the issue tracker that would be resolved by acceptance should be properly linked and referenced.
+- **Issue Reference**: Any bugs or feature requests that have been filed in the issue
+    tracker that would be resolved by acceptance should be properly linked and
+    referenced.
 
 - **Satisfy Automated Tests**: All automated tests associated with the project will be verified to be successful prior to acceptance.
 
-- **Documentation**: Documentation should be included to reflect any new feature or behavior introduced.
+- **Documentation**: Documentation should be included to reflect any new feature or
+    behavior introduced.
 
-- **Release Notes**: Include necessary updates to the release notes or change log to capture a summary of the patched bugs and new feature introduction. Proper linking should be maintained to associated tickets in issue tracker and reviews.
+- **Release Notes**: Include necessary updates to the release notes or change log to
+    capture a summary of the patched bugs and new feature introduction. Proper linking
+    should be maintained to associated tickets in issue tracker and reviews.
 
 ## Release Process
 
-Upon satisfactory adherence to the above Coding Standards, Automated Testing, and Code Reviews:
+Upon satisfactory adherence to the above Coding Standards, Automated Testing, and Code
+Reviews:
 
-- The package version will be incremented following the standard definition of [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with a `Major.Minor.Patch` number.
+- The package version will be incremented following the standard definition of
+  [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with a `Major.Minor.Patch`
+  number.
 
 - Updates will be merged into the base repository `main` branch.
 
 - A new release will be made on PyPI.
 
-For external research teams that reach out to us, we will provide engineering support to help users adopt the updated software, collect feedback, and resolve issues following the processes described in the section below. If the updates require changes in the design of the database schema or formats, a process for data migration will be provided upon request.
+For external research teams that reach out to us, we will provide engineering support to
+help users adopt the updated software, collect feedback, and resolve issues following
+the processes described in the section below. If the updates require changes in the
+design of the database schema or formats, a process for data migration will be provided
+upon request.
 
 ## User Feedback & Issue Tracking
 
-All components will be organized in GitHub repositories with guidelines for contribution, feedback, and issue submission to the issue tracker. For more information on the general policy around issue filing, tracking, and escalation, see the [DataJoint Open-Source Contribute](../../../community/contribution) policy. For research groups that reach out to us, our team will work closely to collect feedback and resolve issues. Typically issues will be prioritized based on their criticality and impact. If new feature requirements become apparent, this may trigger the creation of a separate workflow or a major revision of an existing workflow.
+All components will be organized in GitHub repositories with guidelines for
+contribution, feedback, and issue submission to the issue tracker. For more information
+on the general policy around issue filing, tracking, and escalation, see the
+[DataJoint Open-Source Contribute](../../../community/contribution) policy. For
+research groups that reach out to us, our team will work closely to collect feedback
+and resolve issues. Typically issues will be prioritized based on their criticality and
+impact. If new feature requirements become apparent, this may trigger the creation of a
+separate workflow or a major revision of an existing workflow.

--- a/src/elements/management/selection.md
+++ b/src/elements/management/selection.md
@@ -6,16 +6,28 @@ We have adopted the following general criteria for selecting and accepting new p
 
 1. **Open Precursor Projects**
 
-   At least one open-source DataJoint-based precursor project must exist for any new experiment modality to be accepted for support as part of the Resource. The precursor project team must be open to interviews to describe in detail their process for the experiment workflow, tools, and interfaces.
+   At least one open-source DataJoint-based precursor project must exist for any new
+   experiment modality to be accepted for support as part of the Resource. The
+   precursor project team must be open to interviews to describe in detail their
+   process for the experiment workflow, tools, and interfaces.
 
-   The precursor projects must provide sample data for testing during development and for tutorials. The precursor projects will be acknowledged in the development of the component.
+   The precursor projects must provide sample data for testing during development and
+   for tutorials. The precursor projects will be acknowledged in the development of the
+   component.
 
-   **Rationale:** This Resource does not aim to develop fundamentally new solutions for neurophysiology data acquisition and analysis. Rather it seeks to systematize and disseminate existing open-source tools proven in leading research projects.
+   **Rationale:** This Resource does not aim to develop fundamentally new solutions for
+     neurophysiology data acquisition and analysis. Rather it seeks to systematize and
+     disseminate existing open-source tools proven in leading research projects.
 
 1. **Impact**
 
-   New components proposed for support in the project must be shown to be in demand by a substantial population or research groups, on the order of 100+ labs globally.
+   New components proposed for support in the project must be shown to be in demand by a
+   substantial population or research groups, on the order of 100+ labs globally.
 
 1. **Sustainability**
 
-   For all third-party tools or resources included in the proposed component, their long-term maintenance roadmap must be established. When possible, we will contact the developer team and work with them to establish a sustainability roadmap. If no such roadmap can be established, alternative tools and resources must be identified as replacement.
+   For all third-party tools or resources included in the proposed component, their
+   long-term maintenance roadmap must be established. When possible, we will contact
+   the developer team and work with them to establish a sustainability roadmap. If no
+   such roadmap can be established, alternative tools and resources must be identified
+   as replacement.

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,6 +1,8 @@
 # Glossary
 
-There are many terms that are reused throughout the documentation that we feel important to define together. We've taken careful consideration to be consistent. Below you will find how we've understood and use these terms.
+There are many terms that are reused throughout the documentation that we feel important
+to define together. We've taken careful consideration to be consistent. Below you will
+find how we've understood and use these terms.
 
 | Term | Definition |
 | --- | --- |

--- a/src/projects.md
+++ b/src/projects.md
@@ -1,9 +1,11 @@
 # Projects <!-- 64 -->
 
-DataJoint was originally developed by working systems neuroscientists at Baylor College of Medicine to meet the needs of their own research.
+DataJoint was originally developed by working systems neuroscientists at Baylor College
+of Medicine to meet the needs of their own research.
 
-Below is a partial list of known teams who use DataJoint. 
-Please let us know if you would like to add another group or make other corrections by sending an email to support@datajoint.com.
+Below is a partial list of known teams who use DataJoint. Please let us know if you
+would like to add another group or make other corrections by sending an email to
+support@datajoint.com.
 
 ## Multi-lab collaboratives <!-- 9 -->
 

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -1,11 +1,14 @@
 # :wave: Howdy
 
-Welcome to the home for DataJoint documentation. Here we'll help get you to the right place quickly.
+Welcome to the home for DataJoint documentation. Here we'll help get you to the right
+place quickly.
 
 <br>
 
 The DataJoint ecosystem is divided into 2 distinct areas:
 
-+ **Core**: Fully open-source projects built and designed specifically to support the [DataJoint Mantra](../concepts/mantra).
++ **Core**: Fully open-source projects built and designed specifically to support the
+    [DataJoint Mantra](../concepts/mantra).
 
-+ **Elements**: Fully open-source, data pipelines for neuroscience built with [DataJoint Core](../core).
++ **Elements**: Fully open-source, data pipelines for neuroscience built with
+    [DataJoint Core](../core).


### PR DESCRIPTION
This PR...

1. Adds tabbed blocks to `mkdocs.yaml`
2. Adds a tab block to Mantra.md, providing an example of use
3. Hard wraps markdown files with the goal of making future git diffs easier to read. These single line breaks are not rendered in the output site, but make identifying changes much easier in PRs

No other changes have been made