### PR TITLE
Fix development environment image

### DIFF
--- a/src/elements/user-guide.md
+++ b/src/elements/user-guide.md
@@ -177,7 +177,7 @@ instructions on Jupyter within VS Code).
 enter the following command...
     ```console
     conda install graphviz python-graphviz pydotplus
-```
+    ```
 
 ## Example Config, Workflows and Data
 
@@ -214,6 +214,7 @@ needs.
     ```console
     pip install "element-interface @ git+https://github.com/datajoint/element-interface"
     ```
+
 
 5. <a name="config">&#8203</a>Set up a local DataJoint config file by saving the 
     following block as a json in your workflow directory as `dj_local_conf.json`. Not
@@ -338,6 +339,7 @@ example data, you would ...
     Element and Workflow Array Ephys also support data recorded with 
     OpenEphys.
 
+
 ??? Note "Calcium Imaging: Click to expand details"
     - **Dataset**: workflow-array-calcium-imaging-test-set
     - **Revision**: 0_1_0a2
@@ -406,6 +408,7 @@ example data, you would ...
     - **Dataset**: workflow-facemap
     - **Revision**: 0.0.0
     - **Size**: .3 GB
+
 
 #### Using Your Own Data
 
@@ -735,6 +738,7 @@ provides all the informaiton required to set up a dedicated database.
         model.PoseEstimation.BodyPartPosition()
         ```
     </details>
+
 
 ### DataJoint LabBook
 

--- a/src/elements/user-guide.md
+++ b/src/elements/user-guide.md
@@ -64,10 +64,6 @@ flowchart LR
     style empty2 fill:none, stroke-dasharray: 0 1
     term
   end
-  subgraph ide["Integrated Development Environment"]
-    direction TB
-    empty2
-  end
   class py_interp,conda,term,ide,db_server,DataJoint boxes;
   classDef boxes fill:#ddd, stroke:#333;
 ```
@@ -181,7 +177,7 @@ instructions on Jupyter within VS Code).
 enter the following command...
     ```console
     conda install graphviz python-graphviz pydotplus
-    ```
+```
 
 ## Example Config, Workflows and Data
 
@@ -211,7 +207,6 @@ needs.
         `paths.py` to better suit your needs. If no modification is required, 
         using `pip install .` is sufficient.
     </details>
-
 
 4. Install `element-interface`, which has utilities used across different Elements and 
    Workflows.
@@ -343,7 +338,6 @@ example data, you would ...
     Element and Workflow Array Ephys also support data recorded with 
     OpenEphys.
 
-
 ??? Note "Calcium Imaging: Click to expand details"
     - **Dataset**: workflow-array-calcium-imaging-test-set
     - **Revision**: 0_1_0a2
@@ -412,7 +406,6 @@ example data, you would ...
     - **Dataset**: workflow-facemap
     - **Revision**: 0.0.0
     - **Size**: .3 GB
-
 
 #### Using Your Own Data
 
@@ -742,7 +735,6 @@ provides all the informaiton required to set up a dedicated database.
         model.PoseEstimation.BodyPartPosition()
         ```
     </details>
-
 
 ### DataJoint LabBook
 


### PR DESCRIPTION
Removed the IDE component since technically the terminal is a separate application and can be accessed outside of the IDE.

Before changes:
![image](https://user-images.githubusercontent.com/871137/219700015-82b72fa8-41b0-41b5-ab0c-487e47107116.png)

After changes:
![image](https://user-images.githubusercontent.com/871137/219699744-5bba5b2e-b833-4a62-afc3-0c3c77baed13.png)
