### PR TITLE
Command to activate conda environment fixed

### DIFF
--- a/src/elements/user-guide.md
+++ b/src/elements/user-guide.md
@@ -95,7 +95,7 @@ and go through the setup, including adding Miniconda to your `PATH` (full
 
     ``` console
     conda create --name datajoint-workflow-<name> python=3.9 
-    conda activate dj-workflow-<name> 
+    conda activate datajoint-workflow-<name> 
     ```
 
 ??? Warning "Apple M1 users: Click to expand"


### PR DESCRIPTION
Originally to create and activate a conda environment for DataJoint the following commands were used:

conda create --name datajoint-workflow-<name> python=3.9  conda activate dj-workflow-<name> 

which has been changed to the following as the environment created and the one activated had a different name. Thus I propose the following change to keep it constant and throw the error 'conda environment not found'.

conda create --name datajoint-workflow-<name> python=3.9  conda activate datajoint-workflow-<name>